### PR TITLE
fix: Location not working for cross-assembly compilations

### DIFF
--- a/src/Splat.DependencyInjection.SourceGenerator/MetadataDependencyChecker.cs
+++ b/src/Splat.DependencyInjection.SourceGenerator/MetadataDependencyChecker.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using ReactiveMarbles.RoslynHelpers;
 
@@ -43,10 +45,12 @@ namespace Splat.DependencyInjection.SourceGenerator
                         {
                             if (childConstructor.TypeName == metadataMethod.InterfaceTypeName)
                             {
+                                var location = childConstructor.Parameter.GetLocation(metadataMethod.MethodInvocation);
+
                                 context.ReportDiagnostic(
                                     Diagnostic.Create(
                                         DiagnosticWarnings.ConstructorsMustNotHaveCircularDependency,
-                                        childConstructor.Parameter.Locations.FirstOrDefault(x => x is not null) ?? metadataMethod.MethodInvocation.GetLocation()));
+                                        location));
                                 isError = true;
                             }
                         }
@@ -65,10 +69,12 @@ namespace Splat.DependencyInjection.SourceGenerator
 
                         if (metadataDependencies.TryGetValue(lazyType.ToDisplayString(RoslynCommonHelpers.TypeFormat), out dependencyMethod) && !dependencyMethod.IsLazy)
                         {
+                            var location = constructorDependency.Parameter.GetLocation(metadataMethod.MethodInvocation);
+
                             context.ReportDiagnostic(
                                 Diagnostic.Create(
                                     DiagnosticWarnings.LazyParameterNotRegisteredLazy,
-                                    constructorDependency.Parameter.Locations.FirstOrDefault(x => x is not null) ?? metadataMethod.MethodInvocation.GetLocation(),
+                                    location,
                                     metadataMethod.ConcreteTypeName,
                                     constructorDependency.Parameter.Name));
                             isError = true;
@@ -83,6 +89,18 @@ namespace Splat.DependencyInjection.SourceGenerator
             }
 
             return methods;
+        }
+
+        private static Location GetLocation(this ISymbol symbol, InvocationExpressionSyntax backupInvocation)
+        {
+            var location = symbol.Locations.FirstOrDefault();
+
+            if (location?.Kind != LocationKind.SourceFile)
+            {
+                location = backupInvocation.GetLocation();
+            }
+
+            return location;
         }
     }
 }

--- a/src/Splat.DependencyInjection.SourceGenerator/MetadataDependencyChecker.cs
+++ b/src/Splat.DependencyInjection.SourceGenerator/MetadataDependencyChecker.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/src/Splat.DependencyInjection.SourceGenerator/Splat.DependencyInjection.SourceGenerator.csproj
+++ b/src/Splat.DependencyInjection.SourceGenerator/Splat.DependencyInjection.SourceGenerator.csproj
@@ -1,24 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- forces SDK to copy dependencies into build output to make packing easier -->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageDescription>Produces DI registration for both property and constructor injection using the Splat locators.</PackageDescription>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
     <NoWarn>$(NoWarn);AD0001</NoWarn>
+    <BuildOutputTargetFolder>analyzers</BuildOutputTargetFolder>
+    <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-    <PackageReference Include="ReactiveMarbles.RoslynHelpers" Version="1.0.9" PrivateAssets="all" />
+    <PackageReference Include="ReactiveMarbles.RoslynHelpers" GeneratePathProperty="true" Version="1.0.9" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="PackBuildOutputs">
+  <PropertyGroup>
+  </PropertyGroup>
+
+  <Target Name="GetDependencyTargetPaths">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\**\*" PackagePath="analyzers/dotnet/cs" Visible="false" />
+      <TargetPathWithTargetPlatformMoniker Include="$(PKGReactiveMarbles_RoslynHelpers)\lib\netstandard2.0\ReactiveMarbles.RoslynHelpers.dll" IncludeRuntimeDependency="false" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
The location now defaults to the registration point if not a source location, also the csproj is cleaned up a little bit